### PR TITLE
fix: make ReTend possible even when pawn is tended

### DIFF
--- a/Source/JobDriver_ReTendPatient.cs
+++ b/Source/JobDriver_ReTendPatient.cs
@@ -28,7 +28,7 @@ public class JobDriver_ReTendPatient : JobDriver_TendPatient
 		return true;
 	}
 
-#if V1_2 || V1_3 || V1_4 || V1_5
+#if V1_2 || V1_3 || V1_4 || V1_5 || V1_6
 	protected override IEnumerable<Toil> MakeNewToils()
 #else
 	public override IEnumerable<Toil> MakeNewToils()

--- a/Source/ReTendFloatMenuOptionProvider.cs
+++ b/Source/ReTendFloatMenuOptionProvider.cs
@@ -10,9 +10,9 @@ public class ReTendFloatMenuOptionProvider : FloatMenuOptionProvider
 {
 	// These properties determine when this provider is active.
 	// "ReTend" should be available for both drafted and undrafted pawns.
-	public override bool Drafted => true;
-	public override bool Undrafted => true;
-	public override bool Multiselect => false;
+	protected override bool Drafted => true;
+    protected override bool Undrafted => true;
+    protected override bool Multiselect => false;
 
 	/// <summary>
 	/// This method is called for each pawn under the cursor to see what float menu options are available.

--- a/Source/ReTendFloatMenuOptionProvider.cs
+++ b/Source/ReTendFloatMenuOptionProvider.cs
@@ -38,9 +38,8 @@ public class ReTendFloatMenuOptionProvider : FloatMenuOptionProvider
 		if (doctor.WorkTypeIsDisabled(WorkTypeDefOf.Doctor))
 			yield break; // Exit without providing an option.
 
-		// 2. Check if the target pawn actually needs tending and if re-tending is available.
-		bool needsTending = HealthAIUtility.ShouldBeTendedNowByPlayer(patient) || patient.Downed;
-		if (!needsTending || !ReTendFunctions.ReTendAvailable(patient))
+		// 2. Check if re-tending is available.
+		if (!ReTendFunctions.ReTendAvailable(patient))
 			yield break; // Exit without providing an option.
 
 		// 3. Handle self-tending restrictions.


### PR DESCRIPTION
In the current logic, the targeted pawn must need tending or be downed AND have `ReTend`ing available to be given the option to ReTend. 

This does not make much sense, as the primary point of `ReTend` is to re-try tending on already tended wounds/infections in an effort to improve the quality. The button should appear even on fully tended pawns as long as they have tends below the quality limit.

By removing these checks, we will rely solely on the `ReTendAvailable` function to determine if the `ReTend` option should appear.

resolves #1 
resolves #2 