### PR TITLE
fix: Improve medicine hediff selection logic

### DIFF
--- a/Source/JobDriver_ReTendPatient.cs
+++ b/Source/JobDriver_ReTendPatient.cs
@@ -31,7 +31,7 @@ public class JobDriver_ReTendPatient : JobDriver_TendPatient
 #if V1_2 || V1_3 || V1_4 || V1_5
 	protected override IEnumerable<Toil> MakeNewToils()
 #else
-	public override IEnumerable<Toil> MakeNewToils()
+    protected override IEnumerable<Toil> MakeNewToils()
 #endif
 	{
 		this.FailOnDespawnedNullOrForbidden(TargetIndex.A);

--- a/Source/ReTendFloatMenuOptionProvider.cs
+++ b/Source/ReTendFloatMenuOptionProvider.cs
@@ -10,9 +10,9 @@ public class ReTendFloatMenuOptionProvider : FloatMenuOptionProvider
 {
 	// These properties determine when this provider is active.
 	// "ReTend" should be available for both drafted and undrafted pawns.
-	public override bool Drafted => true;
-	public override bool Undrafted => true;
-	public override bool Multiselect => false;
+	protected override bool Drafted => true;
+    protected override bool Undrafted => true;
+    protected override bool Multiselect => false;
 
 	/// <summary>
 	/// This method is called for each pawn under the cursor to see what float menu options are available.


### PR DESCRIPTION
Current logic has it so that infections cannot be the 'originator' or 'target' of the additional tend capability provided by medicine. 
- If an infection is the selected primary hediff to tend, the medicine tend capability does not activate. 
- If an injury is the primary hediff selected for tending, there's another filter that blocks infections from being secondaries.

This seems to come from checking each `Hediff` against `Hediff_Injury`. The entire `tmpHediffs` list is tightly checked during creation to be only injuries or infections, and severity naturally caps the 'multi-tending' power of medicine. I see no purpose in restricting this from functioning on infections.